### PR TITLE
[BUG] Fix missing selfssl.exe on ChefServer

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -40,7 +40,6 @@ a.out
 *.com
 *.class
 *.dll
-*.exe
 */rdoc/
 
 # Testing #


### PR DESCRIPTION
After upload cookbook to internal ChefServer and execute chef-client command on node.
```
Chef::Exceptions::FileNotFound
-----------------------------
Cookbook 'winrm' (1.0.2) does not contain a file at any of these locations:
files/windows-6.1.7601/selfssl.exe
files/windows/selfssl.exe
files/default/selfssl.exe
files/selfssl.exe
```
